### PR TITLE
Swapped Welcome Message position

### DIFF
--- a/react-app/src/components/messages/messages.js
+++ b/react-app/src/components/messages/messages.js
@@ -63,18 +63,6 @@ function Messages() {
         <div className="messagesAndMembers">
           <div className="messages-and-input">
             <div className="messages-div">
-              <div className="welcomeDiv">
-                <div>
-                  <i class="fas fa-hashtag fa-10x"></i>
-                </div>
-                <span className="welcomeMessage">
-                  Welcome to #{channel?.name}!
-                </span>
-                <div className="welcomeInfo">
-                  This is the start of the #{channel?.name} channel.
-                </div>
-                <hr />
-              </div>
               {isLoaded && (
                 <>
                   {messages?.map((message) => {
@@ -122,6 +110,18 @@ function Messages() {
                       );
                     }
                   })}
+                  <div className="welcomeDiv">
+                  <div>
+                    <i class="fas fa-hashtag fa-10x"></i>
+                  </div>
+                  <span className="welcomeMessage">
+                    Welcome to #{channel?.name}!
+                  </span>
+                  <div className="welcomeInfo">
+                    This is the start of the #{channel?.name} channel.
+                  </div>
+                  <hr />
+              </div>
                 </>
               )}
             </div>


### PR DESCRIPTION
Because of the CSS styling on the messages div, the welcome header and messages were swapped positions. 